### PR TITLE
Исправление двух багов

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Input/Krasnoyarsk.osm
-.idea
+.idea/
+out/
+GraphOfCity.iml

--- a/src/com/company/Main.java
+++ b/src/com/company/Main.java
@@ -47,7 +47,7 @@ public class Main {
                 do {
                     if ("highway".equals(processor.getAttribute("k")) && roads.containsKey(processor.getAttribute("v")) && temp_list.size() > 1)
                         for (int i = 0; i < temp_list.size(); ++i) {
-                            adjacency_list.putIfAbsent(temp_list.get(i), new LinkedHashSet<>((i - 1 < 0) ? Collections.singletonList(temp_list.get(i + 1)) : (i + 1 == temp_list.size()) ? Collections.singletonList(temp_list.get(i - 1)) : Arrays.asList(temp_list.get(i - 1), temp_list.get(i + 1))));
+                            adjacency_list.compute(temp_list.get(i), (k, v) -> (v == null) ? new LinkedHashSet<>() : v).addAll((i - 1 < 0) ? Collections.singletonList(temp_list.get(i + 1)) : (i + 1 == temp_list.size()) ? Collections.singletonList(temp_list.get(i - 1)) : Arrays.asList(temp_list.get(i - 1), temp_list.get(i + 1)));
                             nodes.put(temp_list.get(i), all_nodes.get(temp_list.get(i)));
                         }
                 }while (processor.startElement("tag", "way"));
@@ -92,7 +92,7 @@ public class Main {
             cheker = regular_exp.matcher(str);
         }
         nodes.forEach((k,v) -> out.format(Locale.US, "\t\t<circle r=\"0.2px\" fill=\"blue\" transform=\"translate(%f,%f)\"/>\n", v.get_variable("euclid_X") , v.get_variable("euclid_Y")));
-        adjacency_list.forEach((k1, v1) -> v1.forEach(v2 -> { out.format(Locale.US, "\t\t<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:rgb(255,0,0);stroke-width:0.4\"/>\n", nodes.get(k1).get_variable("euclid_X"), nodes.get(k1).get_variable("euclid_Y"), nodes.get(v2).get_variable("euclid_X"), nodes.get(v2).get_variable("euclid_Y")); adjacency_list.get(v2).remove(k1);}));
+        adjacency_list.forEach((k1, v1) -> v1.forEach(v2 -> { out.format(Locale.US, "\t\t<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:rgb(255,0,0);stroke-width:0.4\"/>\n", nodes.get(k1).get_variable("euclid_X"), nodes.get(k1).get_variable("euclid_Y"), nodes.get(v2).get_variable("euclid_X"), nodes.get(v2).get_variable("euclid_Y"));}));
 
         do { // close tags of general rules
             out.println(str);

--- a/src/com/company/StreamProcessor.java
+++ b/src/com/company/StreamProcessor.java
@@ -11,17 +11,22 @@ public class StreamProcessor implements AutoCloseable{
 
     private final XMLStreamReader reader;
 
+    private boolean firstFlag = false;
+
     StreamProcessor(InputStream is) throws XMLStreamException {
         reader = FACTORY.createXMLStreamReader(is);
     }
 
     boolean startElement(String element, String stop_tag) throws XMLStreamException {
+        if (firstFlag && element.equals(reader.getLocalName()))
+            return !(firstFlag = false);
+
         while (reader.hasNext()) {
             int event = reader.next();
             if (event == XMLEvent.START_ELEMENT && element.equals(reader.getLocalName()))
-                return true;
+                return !(firstFlag = false);
             if(event == XMLEvent.START_ELEMENT && stop_tag.equals(reader.getLocalName()))
-                return false;
+                return !(firstFlag = true);
         }
         return false;
     }


### PR DESCRIPTION
В данном пулл-реквесте выявлены и исправлены следующие баги:

1) ```StreamProcessor``` не проверял  имя текущего элемента на соответствие новому ```element```, в результате чего в двойном ```do{...}while``` пропускался каждый второй way. 
**Пояснение:** 
Вложенный ```do{...}while``` устанавливал указатель ```reader``` на новый way, после чего внешний ```do{...}while``` проверял условие на true путем вызова ```processor.startElement("way", "relation")```. ```startElement``` же вызывал ```reader.next()```, не проверив текущий элемент на соответствие названию элемента, в результате чего указатель ```reader``` смещался на одну позицию вниз, оставляя текущий элемент необработанным. В результате пропускался каждый второй way.

2) При выполнении ```adjacency_list.putIfAbsent()``` не учитывались возвращаемые функцией значения, в результате чего у каждой вершины было не больше 2-х смежных.
Добавление в adjacency_list переписано, стилистика автора сохранена.

Была удалена операция  удаления из adjacency_list при построении графа в функции ```createSVG()```. Данная операция не имеет практического смысла, так как ```forEach()``` гарантирует, что функция будет применена к каждой паре "ключ-значение" ровно один раз.